### PR TITLE
Fix nvImageCodec dependency handling

### DIFF
--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9.yaml
@@ -1,7 +1,7 @@
 astunparse:
 - '>=1.6.0,<=1.6.3'
 aws_sdk_cpp:
-- 1.11.747
+- 1.11.833
 black:
 - 26.*
 c_stdlib:
@@ -50,6 +50,8 @@ libtiff:
 - '4.7'
 lmdb:
 - 0.9.29
+numpy:
+- '2'
 packaging:
 - <=26.0
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0.yaml
@@ -1,7 +1,7 @@
 astunparse:
 - '>=1.6.0,<=1.6.3'
 aws_sdk_cpp:
-- 1.11.747
+- 1.11.833
 black:
 - 26.*
 c_stdlib:
@@ -50,6 +50,8 @@ libtiff:
 - '4.7'
 lmdb:
 - 0.9.29
+numpy:
+- '2'
 packaging:
 - <=26.0
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.17cuda_compiler_version12.9.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.17cuda_compiler_version12.9.yaml
@@ -3,7 +3,7 @@ arm_variant_type:
 astunparse:
 - '>=1.6.0,<=1.6.3'
 aws_sdk_cpp:
-- 1.11.747
+- 1.11.833
 black:
 - 26.*
 c_stdlib:
@@ -52,6 +52,8 @@ libtiff:
 - '4.7'
 lmdb:
 - 0.9.29
+numpy:
+- '2'
 packaging:
 - <=26.0
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.28cuda_compiler_version13.0.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.28cuda_compiler_version13.0.yaml
@@ -3,7 +3,7 @@ arm_variant_type:
 astunparse:
 - '>=1.6.0,<=1.6.3'
 aws_sdk_cpp:
-- 1.11.747
+- 1.11.833
 black:
 - 26.*
 c_stdlib:
@@ -52,6 +52,8 @@ libtiff:
 - '4.7'
 lmdb:
 - 0.9.29
+numpy:
+- '2'
 packaging:
 - <=26.0
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arm_variant_typetegrac_stdlib_version2.34cuda_compiler_version12.9.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typetegrac_stdlib_version2.34cuda_compiler_version12.9.yaml
@@ -3,7 +3,7 @@ arm_variant_type:
 astunparse:
 - '>=1.6.0,<=1.6.3'
 aws_sdk_cpp:
-- 1.11.747
+- 1.11.833
 black:
 - 26.*
 c_stdlib:
@@ -52,6 +52,8 @@ libtiff:
 - '4.7'
 lmdb:
 - 0.9.29
+numpy:
+- '2'
 packaging:
 - <=26.0
 pin_run_as_build:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,121 +23,142 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9
-            STORE_BUILD_ARTIFACTS: True
-            SHORT_CONFIG: linux_64_c_stdlib_version2.17cuda_compil_hd7918865
-            UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
+            CONFIG_SHORT: linux_64_c_stdlib_version2.17cuda_compil_hd7918865
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-            tools_install_dir: ~/miniforge3
+            STORE_BUILD_ARTIFACTS: True
+            UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0
-            STORE_BUILD_ARTIFACTS: True
-            SHORT_CONFIG: linux_64_c_stdlib_version2.28cuda_compil_h282d3825
-            UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
+            CONFIG_SHORT: linux_64_c_stdlib_version2.28cuda_compil_h282d3825
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-            tools_install_dir: ~/miniforge3
+            STORE_BUILD_ARTIFACTS: True
+            UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_arm_variant_typesbsac_stdlib_version2.17cuda_compiler_version12.9
-            STORE_BUILD_ARTIFACTS: True
-            SHORT_CONFIG: linux_aarch64_arm_variant_typesbsac_stdl_h6a4a0357
-            UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
+            CONFIG_SHORT: linux_aarch64_arm_variant_typesbsac_stdl_h6a4a0357
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-            tools_install_dir: ~/miniforge3
+            STORE_BUILD_ARTIFACTS: True
+            UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_arm_variant_typesbsac_stdlib_version2.28cuda_compiler_version13.0
-            STORE_BUILD_ARTIFACTS: True
-            SHORT_CONFIG: linux_aarch64_arm_variant_typesbsac_stdl_h1d8a58f0
-            UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
+            CONFIG_SHORT: linux_aarch64_arm_variant_typesbsac_stdl_h1d8a58f0
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-            tools_install_dir: ~/miniforge3
+            STORE_BUILD_ARTIFACTS: True
+            UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_arm_variant_typetegrac_stdlib_version2.34cuda_compiler_version12.9
-            STORE_BUILD_ARTIFACTS: True
-            SHORT_CONFIG: linux_aarch64_arm_variant_typetegrac_std_h645bfee9
-            UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
+            CONFIG_SHORT: linux_aarch64_arm_variant_typetegrac_std_h645bfee9
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-            tools_install_dir: ~/miniforge3
+            STORE_BUILD_ARTIFACTS: True
+            UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
     steps:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Configure binfmt_misc
+      if: matrix.os == 'ubuntu'
+      shell: bash
+      run: |
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+        fi
 
     - name: Build on Linux
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
-        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
-        CONFIG: ${{ matrix.CONFIG }}
-        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.docker_run_args }}"
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONDA_FORGE_DOCKER_RUN_ARGS: ${{ matrix.docker_run_args }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
+        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
-        if [[ "$(uname -m)" == "x86_64" ]]; then
-          echo "::group::Configure binfmt_misc"
-          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
-        fi
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
-        echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
     - name: Build on macOS
       id: build-macos
       if: matrix.os == 'macos'
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CI: github_actions
         CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        CI: github_actions
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         ./.scripts/run_osx_build.sh
 
     - name: Build on windows
@@ -150,12 +171,14 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
-        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
-        PYTHONUNBUFFERED: 1
-        CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        PYTHONUNBUFFERED: 1
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
@@ -189,18 +212,18 @@ jobs:
       # we do not want to trigger artefact creation if the build was cancelled
       if: ${{ always() && steps.determine-status.outputs.status != 'cancelled' && matrix.STORE_BUILD_ARTIFACTS }}
       env:
-        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
-        SHORT_CONFIG: ${{ matrix.SHORT_CONFIG }}
+        CONFIG_SHORT: ${{ matrix.CONFIG_SHORT }}
         JOB_STATUS: ${{ steps.determine-status.outputs.status }}
         OS: ${{ matrix.os }}
       run: |
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
-        export CI_RUN_ID=$GITHUB_RUN_ID
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
         export ARTIFACT_STAGING_DIR="$GITHUB_WORKSPACE"
+        export CI_RUN_ID=$GITHUB_RUN_ID
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         # Archive everything in CONDA_BLD_PATH except environments
         # Archive the CONDA_BLD_PATH environments only when the job fails
         # Use different prefix for successful and failed build artifacts
@@ -218,7 +241,7 @@ jobs:
         fi
 
     - name: Store conda build artifacts
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ always() && steps.prepare-artifacts.outcome == 'success' }}
       with:
         name: ${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_NAME }}
@@ -227,7 +250,7 @@ jobs:
       continue-on-error: true
 
     - name: Store conda build environment artifacts
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       # only relevant if build failed, see above
       if: ${{ always() && steps.determine-status.outputs.status == 'failure' && steps.prepare-artifacts.outcome == 'success' }}
       with:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -58,16 +58,37 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    echo "rattler-build currently doesn't support debug mode"
-else
+    # differences between conda-build vs. rattler-build
+    #   - 1 step (conda debug + manually open shell) vs. 2 step (rb debug {setup, shell})
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --output-id vs. --output-name
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${FEEDSTOCK_ROOT}/build_artifacts}"
+    rattler-build debug setup \
+        --recipe "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        ${BUILD_OUTPUT_ID:+--output-name "${BUILD_OUTPUT_ID}"} \
+        --target-platform "${HOST_PLATFORM}"
 
-    rattler-build build --recipe "${RECIPE_ROOT}" \
-     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-     ${EXTRA_CB_OPTIONS:-} \
-     --target-platform "${HOST_PLATFORM}" \
-     --extra-meta flow_run_id="${flow_run_id:-}" \
-     --extra-meta remote_url="${remote_url:-}" \
-     --extra-meta sha="${sha:-}"
+    rattler-build debug shell
+else
+    # differences between conda-build vs. rattler-build
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --suppress-variables vs. none
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
+
+    rattler-build build \
+        --recipe "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="${flow_run_id:-}" \
+        --extra-meta remote_url="${remote_url:-}" \
+        --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/.scripts/create_conda_build_artifacts.sh
+++ b/.scripts/create_conda_build_artifacts.sh
@@ -4,10 +4,11 @@
 #
 # CI (azure/github_actions/UNSET)
 # CI_RUN_ID (unique identifier for the CI job run)
-# FEEDSTOCK_NAME
-# CONFIG (build matrix configuration string)
-# SHORT_CONFIG (uniquely-shortened configuration string)
 # CONDA_BLD_PATH (path to the conda-bld directory)
+# CONFIG (build matrix configuration string)
+# CONFIG_SHORT (uniquely-shortened configuration string)
+# FEEDSTOCK_NAME
+# Optional:
 # ARTIFACT_STAGING_DIR (use working directory if unset)
 # BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
 # ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
@@ -49,7 +50,7 @@ fi
 # Set a unique ID for the artifact(s), specialized for this particular job run
 ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
 if [[ ${#ARTIFACT_UNIQUE_ID} -gt 80 ]]; then
-    ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${SHORT_CONFIG}"
+    ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${CONFIG_SHORT}"
 fi
 echo "ARTIFACT_UNIQUE_ID: $ARTIFACT_UNIQUE_ID"
 

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -96,6 +96,14 @@ if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
     fi
 fi
 
+# When running on GitHub Actions, mount the step summary file into the container
+# and point GITHUB_STEP_SUMMARY at it so that rattler-build's GitHub integration
+# can write its summary. GitHub writes the file out to the job summary after the
+# step finishes.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} -v ${GITHUB_STEP_SUMMARY}:/home/conda/github_step_summary:rw${VOLUME_SUFFIX},delegated -e GITHUB_STEP_SUMMARY=/home/conda/github_step_summary"
+fi
+
 ( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
@@ -107,17 +115,20 @@ ${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
 ${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
-           -e CONFIG \
-           -e HOST_USER_ID \
-           -e UPLOAD_PACKAGES \
-           -e IS_PR_BUILD \
-           -e GIT_BRANCH \
-           -e UPLOAD_ON_BRANCH \
-           -e CI \
-           -e FEEDSTOCK_NAME \
-           -e CPU_COUNT \
-           -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e CI \
+           -e CONFIG \
+           -e CPU_COUNT \
+           -e FEEDSTOCK_NAME \
+           -e GIT_BRANCH \
+           -e GITHUB_ACTIONS \
+           -e HOST_USER_ID \
+           -e IS_PR_BUILD \
+           -e RATTLER_BUILD_COLOR \
+           -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
+           -e UPLOAD_ON_BRANCH \
+           -e UPLOAD_PACKAGES \
            -e flow_run_id \
            -e remote_url \
            -e sha \

--- a/build-locally.py
+++ b/build-locally.py
@@ -98,7 +98,10 @@ def main(args=None):
     p.add_argument(
         "--debug",
         action="store_true",
-        help="Setup debug environment using `conda debug`",
+        help=(
+            "Setup debug environment using `conda debug` "
+            "(or `rattler-build debug` for rattler-build recipes)"
+        ),
     )
     p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -20,3 +20,8 @@ packaging:
 # https://github.com/NVIDIA/DALI/blob/v1.47.0/pyproject.toml
 black:
   - "26.*"
+# DALI uses only numpy Python API (no C ABI) - no runtime pinning needed
+numpy:
+  - "2"
+ignore_version:
+  - numpy

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -23,7 +23,7 @@ source:
     target_directory: third_party/ffts
 
 build:
-  number: 0
+  number: 1
   skip:
     - cuda_compiler_version == "None"
     - win
@@ -282,6 +282,7 @@ outputs:
         - gast ${{ gast }}
         - six ${{ six }}
         - optree
+        - numpy
         - packaging ${{ packaging }}
         # Stubs autoformat themselves
         - black  ${{ black }}
@@ -294,6 +295,7 @@ outputs:
         - gast ${{ gast }}
         - six ${{ six }}
         - optree
+        - numpy
         - packaging ${{ packaging }}
         - ${{ pin_compatible('cuda-version', lower_bound='x', upper_bound='x') }}
     tests:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -295,7 +295,6 @@ outputs:
         - gast ${{ gast }}
         - six ${{ six }}
         - optree
-        - numpy
         - packaging ${{ packaging }}
         - ${{ pin_compatible('cuda-version', lower_bound='x', upper_bound='x') }}
     tests:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -64,6 +64,11 @@ outputs:
         - libnpp-dev
         - libnvjpeg-dev
         - libnvjpeg-static
+        - libnvjpeg2k-dev  ${{ libnvjpeg2k }}
+        - if: (arm_variant_type | default("")) != "tegra"
+          then:
+            - libnvcomp-dev  ${{ libnvcomp }}
+        - libnvimgcodec-dev  ${{ libnvimgcodec }}
         - cuda-version ${{ cuda_compiler_version }}.*
         - aws-sdk-cpp
         - cfitsio
@@ -74,11 +79,6 @@ outputs:
         - libabseil
         - libboost-headers  ${{ libboost_headers }}.*
         - libjpeg-turbo
-        - if: (arm_variant_type | default("")) != "tegra"
-          then:
-            - libnvcomp-dev  ${{ libnvcomp }}
-        - libnvimgcodec-dev  ${{ libnvimgcodec }}
-        - libnvjpeg2k-dev  ${{ libnvjpeg2k }}
         - libopencv
         - libprotobuf
         - libprotobuf-static
@@ -131,20 +131,12 @@ outputs:
         - cuda-version ${{ cuda_compiler_version }}.*
       run:
         - ${{ pin_compatible('cuda-version', lower_bound='x', upper_bound='x') }}
-      run_constraints:
-        # These packages are dlopen'd and are already constrained by cuda-version
-        # FIXME: Consider a meta-package like "nvidia-dali-all" for convenience
-        # - if: match(cuda_compiler_version, "12.*")
-        #   then:
-        #     - libcufft
-        #     - libcufile
-        #     - libnpp
-        #     - libnvjpeg
-        - libboost-headers  ${{ libboost_headers }}.*
+        - libnvimgcodec ${{ libnvimgcodec }}
         - if: (arm_variant_type | default("")) != "tegra"
           then:
             - libnvcomp  ${{ libnvcomp }}
-        - libnvimgcodec ${{ libnvimgcodec }}
+      run_constraints:
+        - libboost-headers  ${{ libboost_headers }}.*
     tests:
       - script:
           - test -f "${PREFIX}/lib/libdali.so"
@@ -232,6 +224,14 @@ outputs:
           # The Python extension links only against libdali*.so and system libs.
           - libnvjpeg2k-dev
           - zlib
+          - libcufft-dev
+          - libcufile-dev
+          - libcurand-dev
+          - libnpp-dev
+          - libnvimgcodec-dev
+          - if: (arm_variant_type | default("")) != "tegra"
+            then:
+              - libnvcomp-dev
       build:
         - ${{ compiler('cuda') }}
         - ${{ compiler('cxx') }}
@@ -261,10 +261,14 @@ outputs:
         - libnvjpeg-dev
         - libnvjpeg-static
         - cuda-version ${{ cuda_compiler_version }}.*
-        - cutlass
-        - dlpack
         - libboost-headers  ${{ libboost_headers }}.*
         - libnvjpeg2k-dev  ${{ libnvjpeg2k }}
+        - if: (arm_variant_type | default("")) != "tegra"
+          then:
+            - libnvcomp-dev  ${{ libnvcomp }}
+        - libnvimgcodec-dev  ${{ libnvimgcodec }}
+        - cutlass
+        - dlpack
         - libprotobuf
         - libprotobuf-static
         - nvtx-c


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered](https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

This updates the DALI Python output dependencies so its per-Python CMake configure step can find conda-forge-provided nvImageCodec headers instead of falling back to downloading them from nvidia.com during the build.

Changes:
* add `libnvimgcodec-dev`, `libnvjpeg2k-dev`, and `libnvcomp-dev` to the relevant host environments before CMake feature detection
* keep `libnvimgcodec-dev` as a build-time dependency only by ignoring its run exports
* make `libdali` depend explicitly on runtime `libnvimgcodec`
* keep Python runtime dependencies owned through `libdali`